### PR TITLE
Obs window size

### DIFF
--- a/ensemble_profiler/constants.py
+++ b/ensemble_profiler/constants.py
@@ -19,8 +19,8 @@ PATIENT_NAME_PREFIX = "patient"
 #: nursery actor name
 NURSERY_ACTOR = "HEALTH_SRTML_PATIENT_NURSERY"
 
-#: Prediction Interval for
-PREDITICATE_INTERVAL = 3750
+#: Prediction Interval for 30 sec * 250 Hz
+PREDITICATE_INTERVAL = 7500
 
 #: Profiling Ensemble
 PROFILE_ENSEMBLE = "/profileEnsemble"

--- a/ensemble_profiler/latency.py
+++ b/ensemble_profiler/latency.py
@@ -5,7 +5,7 @@ from ensemble_profiler.utils import *
 import time
 from ensemble_profiler.server import HTTPActor
 import subprocess
-from ensemble_profiler.constants import ROUTE_ADDRESS, PROFILE_ENSEMBLE
+from ensemble_profiler.constants import ROUTE_ADDRESS, PROFILE_ENSEMBLE, PREDITICATE_INTERVAL
 from ensemble_profiler.tq_simulator import find_tq
 import time
 from threading import Event
@@ -20,10 +20,10 @@ import numpy as np
 package_directory = os.path.dirname(os.path.abspath(__file__))
 
 
-def _calculate_throughput_ensemble(pipeline):
+def _calculate_throughput_ensemble(pipeline, obs_w_30sec):
     num_queries = 100
     start_time = time.time()
-    futures = [pipeline.remote(data=torch.zeros(1, 1, 3750))
+    futures = [pipeline.remote(data=torch.zeros(obs_w_30sec, 1, PREDITICATE_INTERVAL))
                for _ in range(num_queries)]
     result = ray.get(futures)
     end_time = time.time()
@@ -93,7 +93,7 @@ def profile_ensemble(model_list, file_path,
 
             if not with_data_collector:
                 # calculating the throughput
-                mu_qps = _calculate_throughput_ensemble(pipeline)
+                mu_qps = _calculate_throughput_ensemble(pipeline, obs_w_30sec)
                 print("Throughput of Ensemble is : {} QPS".format(mu_qps))
                 lambda_qps = _heuristic_lambda_calculation(mu_qps)
                 waiting_time_ms = 1000.0/lambda_qps

--- a/ensemble_profiler/latency.py
+++ b/ensemble_profiler/latency.py
@@ -48,7 +48,8 @@ def _calculate_latency(file_name, p=95):
 
 def profile_ensemble(model_list, file_path,
                      constraint={"gpu": 1, "npatient": 1}, http_host="0.0.0.0",
-                     fire_clients=True, with_data_collector=False):
+                     fire_clients=True, with_data_collector=False, 
+                     obs_w_30sec=1):
     if not ray.is_initialized():
         # read constraint
         num_patients = int(constraint["npatient"])
@@ -140,7 +141,8 @@ def profile_ensemble(model_list, file_path,
                               "serve_ip": IPv4addr,
                               "serve_port": serve_port,
                               "go_client_name": "profile_ensemble",
-                              "waiting_time_ms": waiting_time_ms}
+                              "waiting_time_ms": waiting_time_ms,
+                              "obs_w_30sec":obs_w_30sec}
             fire_remote_clients(url, req_params)
             print("finish firing remote clients")
             serve.shutdown()

--- a/ensemble_profiler/latency.py
+++ b/ensemble_profiler/latency.py
@@ -118,7 +118,7 @@ def profile_ensemble(model_list, file_path,
                 for patient_name in actor_handles.keys():
                     final_cmd = cmd + [patient_name]
                     if not with_data_collector:
-                        final_cmd += [str(waiting_time_ms)]
+                        final_cmd += [str(waiting_time_ms), str(obs_w_30sec)]
                     ls_output = subprocess.Popen(final_cmd)
                     procs.append(ls_output)
                 for p in procs:

--- a/ensemble_profiler/profile_ensemble.go
+++ b/ensemble_profiler/profile_ensemble.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		time_ms = 20.0
 	}
+	obs_w_30sec := os.Args[3]
 	fmt.Println(patient_name)
 	fmt.Print(time_ms)
 	ch := make(chan string)
@@ -32,7 +33,7 @@ func main() {
 		time.Sleep(time.Duration(time_ms) * time.Millisecond)
 		// This how actual client will send the result
 		go MakeRequest("http://127.0.0.1:8000/profileEnsemble?patient_name="+
-			patient_name+"&value=0.0&vtype=ECG", ch)
+			patient_name+"&value=0.0&obs_w_30sec="+ obs_w_30sec + "&vtype=ECG", ch)
 		// This is how profiling result is send
 		//go MakeRequest("http://127.0.0.1:8000/RayServeProfile/hospital", ch)
 	}

--- a/ensemble_profiler/server.py
+++ b/ensemble_profiler/server.py
@@ -111,7 +111,11 @@ class HTTPProxy:
             raise ValueError("Multiple Patients specified."
                              "Specify only one.")
         patient_name = patient_name[0]
-        prediction_tensor = torch.zeros((1, 1, PREDITICATE_INTERVAL))
+
+        obs_w_30sec = query_kwargs.pop("obs_w_30sec", None)
+        if obs_w_30sec is None:
+            raise ValueError("Specify obs_w_30sec in query")
+        prediction_tensor = torch.zeros((obs_w_30sec, 1, PREDITICATE_INTERVAL))
 
         request_sent_time = time.time()
         result = await self.ensemble_pipeline.remote(data=prediction_tensor)

--- a/ensemble_profiler/server.py
+++ b/ensemble_profiler/server.py
@@ -115,7 +115,7 @@ class HTTPProxy:
         obs_w_30sec = query_kwargs.pop("obs_w_30sec", None)
         if obs_w_30sec is None:
             raise ValueError("Specify obs_w_30sec in query")
-        obs_w_30sec = obs_w_30sec[0]
+        obs_w_30sec = int(obs_w_30sec[0])
         prediction_tensor = torch.zeros((obs_w_30sec, 1, PREDITICATE_INTERVAL))
 
         request_sent_time = time.time()

--- a/ensemble_profiler/server.py
+++ b/ensemble_profiler/server.py
@@ -115,6 +115,7 @@ class HTTPProxy:
         obs_w_30sec = query_kwargs.pop("obs_w_30sec", None)
         if obs_w_30sec is None:
             raise ValueError("Specify obs_w_30sec in query")
+        obs_w_30sec = obs_w_30sec[0]
         prediction_tensor = torch.zeros((obs_w_30sec, 1, PREDITICATE_INTERVAL))
 
         request_sent_time = time.time()

--- a/ensemble_profiler/server.py
+++ b/ensemble_profiler/server.py
@@ -111,7 +111,12 @@ class HTTPProxy:
             raise ValueError("Multiple Patients specified."
                              "Specify only one.")
         patient_name = patient_name[0]
-        prediction_tensor = torch.zeros((1, 1, PREDITICATE_INTERVAL))
+
+        obs_w_30sec = query_kwargs.pop("obs_w_30sec", None)
+        if obs_w_30sec is None:
+            raise ValueError("Specify obs_w_30sec in query")
+        obs_w_30sec = int(obs_w_30sec[0])
+        prediction_tensor = torch.zeros((obs_w_30sec, 1, PREDITICATE_INTERVAL))
 
         request_sent_time = time.time()
         result = await self.ensemble_pipeline.remote(data=prediction_tensor)

--- a/ensemble_profiler/tq_simulator.py
+++ b/ensemble_profiler/tq_simulator.py
@@ -28,8 +28,8 @@ def find_max_horizontal_distance(arrival_curve, service_curve, x_val):
     # for arrival curve should be
     # greater than x_values for service curve as arrival
     # curve is above service curve before crossing index
-    assert all([d > 0 for d in distance_list])
     max_distance = max(distance_list)
+    assert max_distance > 0
     return max_distance
 
 


### PR DESCRIPTION
1. Change the frequency from 125Hz to 250Hz
We change the firing frequency according to dataset. 
This means prediction will happen after 30 sec * 250Hz = 7500 request

2. Change the server to accomodate obs_w_30sec.
obs_w_30sec is equal to batch size of waveform with observation window of 30 sec.
For example if we want to do profile_ensemble of 5 minutes of waveform we will send tensor in size of (obs_w_30sec, 1, 7500). 